### PR TITLE
Add aliases

### DIFF
--- a/src/components/badges.astro
+++ b/src/components/badges.astro
@@ -1,5 +1,5 @@
 ---
-import Badge from './badge.astro';
+import Badge from '@/components/badge.astro';
 ---
 
 <Badge src="/badges/88x31.gif" href="//cyber.dabamos.de/88x31" />

--- a/src/components/posts.astro
+++ b/src/components/posts.astro
@@ -1,5 +1,5 @@
 ---
-import Post from "./post.astro";
+import Post from "@/components/post.astro";
 const posts = await Astro.glob("/src/pages/posts/*.md");
 ---
 

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -1,5 +1,5 @@
 ---
-import Badges from "../components/badges.astro";
+import Badges from "@/components/badges.astro";
 const { title, description, tags } = Astro.props;
 ---
 

--- a/src/layouts/post.astro
+++ b/src/layouts/post.astro
@@ -1,5 +1,5 @@
 ---
-import Layout from "./layout.astro";
+import Layout from "@/layouts/layout.astro";
 const { frontmatter } = Astro.props;
 const date = new Date(frontmatter.pubDate).toLocaleDateString("en-US", {
     year: "numeric",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
-import Posts from "../components/posts.astro";
-import Layout from "../layouts/layout.astro";
-import WhoAmI from "./whoami.astro";
+import Posts from "@/components/posts.astro";
+import Layout from "@/layouts/layout.astro";
+import WhoAmI from "@/pages/whoami.astro";
 
 const meta = {
     description: "I love to program! In my day-to-day life I work as a systems administrator."

--- a/src/pages/posts/2023-10-06.md
+++ b/src/pages/posts/2023-10-06.md
@@ -1,5 +1,5 @@
 ---
-layout: ../../layouts/post.astro
+layout: "@/layouts/post.astro"
 title: "What's up with your name?"
 pubDate: 2023-10-06
 description: "Morgan is my legal name, Hazel is my preferred name, which one you end up using doesn't really matter."

--- a/src/pages/posts/2024-04-19.md
+++ b/src/pages/posts/2024-04-19.md
@@ -1,5 +1,5 @@
 ---
-layout: ../../layouts/post.astro
+layout: "@/layouts/post.astro"
 title: "Listing posts with Astro"
 pubDate: 2024-04-19
 description: "This post alone would've been a pain to make in plain HTML."

--- a/src/pages/posts/2024-04-26.md
+++ b/src/pages/posts/2024-04-26.md
@@ -1,5 +1,5 @@
 ---
-layout: ../../layouts/post.astro
+layout: "@/layouts/post.astro"
 title: "Broadcasting my resume across the interwebz"
 pubDate: 2024-04-26
 description: "To whom it may concern, here's documented evidence I'm a nerd."

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,6 +1,6 @@
 ---
-import Project from "../../components/project.astro";
-import Layout from "../../layouts/layout.astro";
+import Project from "@/components/project.astro";
+import Layout from "@/layouts/layout.astro";
 const projects = await Astro.glob("./*.md");
 
 const meta = {

--- a/src/pages/resume/index.astro
+++ b/src/pages/resume/index.astro
@@ -1,5 +1,5 @@
 ---
-import Layout from "../../layouts/layout.astro";
+import Layout from "@/layouts/layout.astro";
 
 const meta = {
     title: "Resume",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,10 @@
 {
-  "extends": "astro/tsconfigs/base"
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
 }


### PR DESCRIPTION
Changes the imports to use [Aliases](https://docs.astro.build/en/guides/aliases/) so paths are absolute but not annoyingly long.

e.g. `../../layouts/post.astro` -> `"@/layouts/post.astro"`

As a side note, you have two instances of `post.astro` which would be ambiguous for the relative paths.