### PR TITLE
Refactor styles

### DIFF
--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -15,40 +15,38 @@ const { title, description, tags } = Astro.props;
         <meta name="keywords" content={tags} />
     </head>
     <body>
-        <div id="content">
-            <header>
-                <span class="tag"><a href="/posts/2023-10-06">Hazel</a>, that's me.</span>
-                <div>
-                    <a href="/" title="My homepage">Home</a>
-                    |
-                    <a href="/projects" title="Projects I've worked on">Projects</a>
-                    |
-                    <a href="/resume" title="My resume in printable formats">Resume</a>
-                </div>
-            </header>
-            <main>
-                <slot />
-            </main>
-            <footer>
-                <i>Favicon by <a href="https://github.com/dvrossen">DvRossen</a></i>
+        <header>
+            <span class="tag"><a href="/posts/2023-10-06">Hazel</a>, that's me.</span>
+            <div>
+                <a href="/" title="My homepage">Home</a>
+                |
+                <a href="/projects" title="Projects I've worked on">Projects</a>
+                |
+                <a href="/resume" title="My resume in printable formats">Resume</a>
+            </div>
+        </header>
+        <main>
+            <slot />
+        </main>
+        <footer>
+            <i>Favicon by <a href="https://github.com/dvrossen">DvRossen</a></i>
 
-                <div>
-                    <a
-                        href="https://webring.queercoded.dev/prev?source=hazelthats.me"
-                        >{`<-`}</a
-                    >
-                    <i>Part of the Queer Coded webring.</i>
-                    <a
-                        href="https://webring.queercoded.dev/next?source=hazelthats.me"
-                        >{`->`}</a
-                    >
-                </div>
+            <div>
+                <a
+                    href="https://webring.queercoded.dev/prev?source=hazelthats.me"
+                    >{`<-`}</a
+                >
+                <i>Part of the Queer Coded webring.</i>
+                <a
+                    href="https://webring.queercoded.dev/next?source=hazelthats.me"
+                    >{`->`}</a
+                >
+            </div>
 
-                <div class="badges">
-                    <Badges />
-                </div>
-            </footer>
-        </div>
+            <div class="badges">
+                <Badges />
+            </div>
+        </footer>
     </body>
 </html>
 <style is:global>
@@ -59,14 +57,14 @@ const { title, description, tags } = Astro.props;
         font-size: 16px;
     }
 
-    #content {
+    header, main, footer {
         margin: 1rem auto;
         width: 90vw;
         max-width: 1000px;
     }
 
     main {
-        margin: 5rem 0;
+        padding: 5rem 0;
     }
 
     .tag {

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -32,7 +32,7 @@ const { title, description, tags } = Astro.props;
         <footer>
             <i>Favicon by <a href="https://github.com/dvrossen">DvRossen</a></i>
 
-            <div>
+            <div class="webring">
                 <a
                     href="https://webring.queercoded.dev/prev?source=hazelthats.me"
                     >{`<-`}</a
@@ -55,10 +55,15 @@ const { title, description, tags } = Astro.props;
     .title {
         font-size: 4rem;
         font-weight: bold;
+        margin-bottom: 1rem;
     }
+
+    .webring {
+        margin-bottom: 1rem;
     }
 
     .badges img {
         margin: 5px;
     }
+
 </style>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -1,4 +1,5 @@
 ---
+import "../styles/global.css"
 import Badges from "../components/badges.astro";
 const { title, description, tags } = Astro.props;
 ---
@@ -49,55 +50,14 @@ const { title, description, tags } = Astro.props;
         </footer>
     </body>
 </html>
-<style is:global>
-    body {
-        background-color: black;
-        color: white;
-        font-family: monospace;
-        font-size: 16px;
-    }
 
-    header, main, footer {
-        margin: 1rem auto;
-        width: 90vw;
-        max-width: 1000px;
-    }
-
-    main {
-        padding: 5rem 0;
-    }
-
+<style>
     .tag {
         font-size: 4rem;
         font-weight: bold;
     }
 
-    header, footer {
-        text-align: center;
-    }
-    
-	.badges img {
-		margin: 5px;
-	}
-
-    a {
-        color: cyan;
-    }
-
-    a:visited {
-        color: aquamarine;
-    }
-
-    code {
-        background-color: gray;
-        color: white;
-    }
-
-    pre {
-        padding: 1em;
-    }
-
-    pre code {
-        background-color: transparent;
+    .badges img {
+        margin: 5px;
     }
 </style>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -17,7 +17,7 @@ const { title, description, tags } = Astro.props;
     </head>
     <body>
         <header>
-            <span class="tag"><a href="/posts/2023-10-06">Hazel</a>, that's me.</span>
+            <div class="title"><a href="/posts/2023-10-06">Hazel</a>, that's me.</div>
             <div>
                 <a href="/" title="My homepage">Home</a>
                 |
@@ -52,9 +52,10 @@ const { title, description, tags } = Astro.props;
 </html>
 
 <style>
-    .tag {
+    .title {
         font-size: 4rem;
         font-weight: bold;
+    }
     }
 
     .badges img {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,43 @@
+body {
+  background-color: black;
+  color: white;
+  font-family: monospace;
+  font-size: 16px;
+}
+
+header,
+main,
+footer {
+  margin-inline: auto;
+  padding: 1rem;
+  max-width: 1000px;
+}
+
+main {
+  padding-block: 5rem;
+}
+header,
+footer {
+  text-align: center;
+}
+
+a {
+  color: cyan;
+}
+
+a:visited {
+  color: aquamarine;
+}
+
+code {
+  background-color: gray;
+  color: white;
+}
+
+pre {
+  padding: 1em;
+}
+
+pre code {
+  background-color: transparent;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,9 +14,6 @@ footer {
   max-width: 1000px;
 }
 
-main {
-  padding-block: 5rem;
-}
 header,
 footer {
   text-align: center;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,5 @@
 body {
+  margin: 0;
   background-color: black;
   color: white;
   font-family: monospace;


### PR DESCRIPTION
Changes the styles to be in an external style sheet (imported on compile time, of course) for all the styles that should be global. Scopes the rest.

There are also some small spacing changes, but that could be changed by modifying the margin styles on `main` and/or the styles left in `index.astro`.

Before:

![image](https://github.com/hazelthatsme/hazelthats.me/assets/109556932/7e9a9c36-0e08-4203-8b1b-189fd40e9ac0)

After:

![image](https://github.com/hazelthatsme/hazelthats.me/assets/109556932/6bea5da4-55a3-4f84-9f0c-2c24f511e204)

