### PR TITLE
Refactor badges

### DIFF
--- a/src/components/badge.astro
+++ b/src/components/badge.astro
@@ -1,10 +1,23 @@
 ---
-const {src, href} = Astro.props;
+type Props = {
+    src: string;
+    title?: string;
+    href?: string;
+};
+const { src, title, href } = Astro.props;
 ---
 
-<a href={href} class="badge">
-    <img src={src} />
-</a>
+<span class="badge">
+{
+    href !== undefined ? (
+        <a href={href} aria-label={title} class="badge">
+            <img src={src} alt="" />
+        </a>
+    ) : (
+        <img src={src} alt="" />
+    )
+}
+</span>
 
 <style>
     a {

--- a/src/components/badge.astro
+++ b/src/components/badge.astro
@@ -21,7 +21,6 @@ const { src, title, href } = Astro.props;
 
 <style>
     a {
-        color: none;
         text-decoration: none;
     }
 </style>

--- a/src/components/badges.astro
+++ b/src/components/badges.astro
@@ -1,19 +1,29 @@
 ---
-import Badge from './badge.astro';
+import Badge from "./badge.astro";
+
+type Badge = {
+    src: string;
+    title?: string;
+    href?: string;
+};
+
+const badgeList: Badge[] = [
+    { src: "/badges/88x31.gif", title: "88x31 Badges", href: "//cyber.dabamos.de/88x31" },
+    { src: "/badges/bitwarden.gif" },
+    { src: "/badges/button25.gif" },
+    { src: "/badges/fedora.gif", title: "Fedora", href: "//fedoraproject.org/spins/minimal/download", },
+    { src: "/badges/firefox2.gif" },
+    { src: "/badges/github-check.gif", title: "Github", href: "//github.com/hazelthatsme" },
+    { src: "/badges/gnu-linux.gif", title: "GNU Kernel", href: "//kernel.org" },
+    { src: "/badges/google_stand.gif" },
+    { src: "/badges/knbutton.gif", title: "KDE", href: "//kde.org" },
+    { src: "/badges/internetprivacy.gif" },
+    { src: "/badges/minecraft.gif", title: "Minecraft", href: "//minecraft.net" },
+    { src: "/badges/qc-88x31.gif", title: "Queercoded Webring", href: "//webring.queercoded.dev" },
+    { src: "/badges/transnow2.gif" },
+    { src: "/badges/ubuntu-88x31.gif", title: "Ubuntu", href: "//ubuntu.com/server" },
+    { src: "/badges/wikipedia.gif", title: "Wikipedia", href: "//donate.wikimedia.org/wiki/Special:FundraiserRedirector", },
+];
 ---
 
-<Badge src="/badges/88x31.gif" href="//cyber.dabamos.de/88x31" />
-<Badge src="/badges/bitwarden.gif" />
-<Badge src="/badges/button25.gif" />
-<Badge src="/badges/fedora.gif" href="//fedoraproject.org/spins/minimal/download" />
-<Badge src="/badges/firefox2.gif" />
-<Badge src="/badges/github-check.gif" href="//github.com/hazelthatsme" />
-<Badge src="/badges/gnu-linux.gif" href="//kernel.org" />
-<Badge src="/badges/google_stand.gif" />
-<Badge src="/badges/knbutton.gif" href="//kde.org" />
-<Badge src="/badges/internetprivacy.gif" />
-<Badge src="/badges/minecraft.gif" href="//minecraft.net" />
-<Badge src="/badges/qc-88x31.gif" href="//webring.queercoded.dev" />
-<Badge src="/badges/transnow2.gif" />
-<Badge src="/badges/ubuntu-88x31.gif" href="//ubuntu.com/server" />
-<Badge src="/badges/wikipedia.gif" href="//donate.wikimedia.org/wiki/Special:FundraiserRedirector" />
+{badgeList.map((badge) => <Badge {...badge} />)}


### PR DESCRIPTION
Changes badges to be created based on a mapped object rather than duplicated markup. Also fixes the issue of non-link badges having an anchor tag wrapper.

This has no visual difference, though it will likely be much more convenient to expand.