### PR TITLE
Fix projects page images for mobile

### DIFF
--- a/src/components/project.astro
+++ b/src/components/project.astro
@@ -17,8 +17,8 @@ const { title, image, url, url_text, content } = Astro.props;
 
 <style>
     .project {
-        display: flex;
-        flex-direction: row;
+        display: grid;
+        grid-template-columns: auto 1fr;
         align-items: center;
         gap: 1rem;
         margin: 1rem 0;
@@ -30,5 +30,14 @@ const { title, image, url, url_text, content } = Astro.props;
 
     .project h2 {
         margin: 0;
+    }
+
+    @media (width < 800px) {
+        .project {
+            grid-template-columns: 1fr;
+        }
+        .project .thumbnail {
+            max-height: unset;
+        }
     }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,3 +39,8 @@ pre {
 pre code {
   background-color: transparent;
 }
+
+img {
+  max-width: 100%;
+  max-height: 100%;
+}


### PR DESCRIPTION
Currently, images in the projects page break the viewing experience. This pull request changes how they are displayed with `grid` magic to make them automatically wrap to look neat.

Before:

![image](https://github.com/hazelthatsme/hazelthats.me/assets/109556932/1b05063a-9f43-418e-84c3-db15cfef19b9)

After:

![image](https://github.com/hazelthatsme/hazelthats.me/assets/109556932/00236036-722c-4d67-b8a4-76f585f2cbc0)

yay
